### PR TITLE
Revert "Change default response to non-converging GLM"

### DIFF
--- a/src/glm_local_regression.jl
+++ b/src/glm_local_regression.jl
@@ -67,11 +67,11 @@ function glm_local_Σ(;
         catch e
             if e isa StatsBase.ConvergenceException
                 @warn """
-                GLM did not converge. This may occur if the quadratic regression
-                is biased. Corresponding variance set to 0.1*sample covariance.
+                GLM did not converge. Corresponding variance set to sample
+                covariance.
                 """
                 fallback = zeros(n_θ + 1)
-                fallback[1] = log(0.1*samp_Σ[i,i])
+                fallback[1] = log(samp_Σ[i,i])
                 coefs[i, :] = fallback
             else
                 throw(e)

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -93,7 +93,7 @@ function update!(
 
     z = randn(length(θ))
 
-    Δ = (ϵ^2 .* H⁻¹*∇)/2 .+ ϵ*sqrt(H⁻¹) * z
+    Δ = (ϵ^2 .* H⁻¹*∇ )/2 .+ ϵ*sqrt(H⁻¹) * z
     Δ = halve_update_until_valid(Δ, θ, valid_params)
 
     state.θ = θ .- Δ


### PR DESCRIPTION
Reverts danielward27/SyntheticLikelihood.jl#43

Idea was that biased regression leads to inflated residuals, but probably doesn't make sense.